### PR TITLE
dvach: Возможность выбрать полную клавиатуру для капчи

### DIFF
--- a/extensions/dvach/res/values-ru/strings.xml
+++ b/extensions/dvach/res/values-ru/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <string name="preference_captcha_full_keyboard">Использовать полную клавиатуру для капчи</string>
+</resources>

--- a/extensions/dvach/res/values/strings.xml
+++ b/extensions/dvach/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <string name="preference_captcha_full_keyboard">Use full keyboard for captcha</string>
+</resources>

--- a/extensions/dvach/src/com/mishiranu/dashchan/chan/dvach/DvachChanConfiguration.java
+++ b/extensions/dvach/src/com/mishiranu/dashchan/chan/dvach/DvachChanConfiguration.java
@@ -1,13 +1,17 @@
 package com.mishiranu.dashchan.chan.dvach;
 
+import android.content.res.Resources;
 import android.util.Pair;
+
 import chan.content.ChanConfiguration;
 import chan.util.CommonUtils;
 import chan.util.StringUtils;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -33,6 +37,8 @@ public class DvachChanConfiguration extends ChanConfiguration {
 	private static final String KEY_FLAGS_ENABLED = "flags_enabled";
 	private static final String KEY_MAX_COMMENT_LENGTH = "max_comment_length";
 
+	private static final String KEY_CAPTCHA_FULL_KEYBOARD = "captcha_full_keyboard";
+
 	public DvachChanConfiguration() {
 		request(OPTION_READ_THREAD_PARTIALLY);
 		request(OPTION_READ_SINGLE_POST);
@@ -44,6 +50,7 @@ public class DvachChanConfiguration extends ChanConfiguration {
 		for (String captchaType : CAPTCHA_TYPES.keySet()) {
 			addCaptchaType(captchaType);
 		}
+		addCustomPreference(KEY_CAPTCHA_FULL_KEYBOARD, false);
 	}
 
 	@Override
@@ -184,4 +191,21 @@ public class DvachChanConfiguration extends ChanConfiguration {
 		}
 		return description;
 	}
+
+	@Override
+	public CustomPreference obtainCustomPreferenceConfiguration(String key) {
+		if (key.equals(KEY_CAPTCHA_FULL_KEYBOARD)) {
+			Resources resources = getResources();
+			String title = resources.getString(R.string.preference_captcha_full_keyboard);
+			CustomPreference captchaFullKeyboardPreference = new CustomPreference();
+			captchaFullKeyboardPreference.title = title;
+			return captchaFullKeyboardPreference;
+		}
+		return null;
+	}
+
+	boolean isFullKeyboardForCaptchaEnabled() {
+		return get(null, KEY_CAPTCHA_FULL_KEYBOARD, false);
+	}
+
 }

--- a/extensions/dvach/src/com/mishiranu/dashchan/chan/dvach/DvachChanPerformer.java
+++ b/extensions/dvach/src/com/mishiranu/dashchan/chan/dvach/DvachChanPerformer.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 
 import chan.content.ApiException;
-import chan.content.ChanConfiguration;
 import chan.content.ChanPerformer;
 import chan.content.InvalidResponseException;
 import chan.content.RedirectException;
@@ -975,25 +974,25 @@ public class DvachChanPerformer extends ChanPerformer {
 						throw new InvalidResponseException();
 					}
 					result.setImage(image);
-					/*
-					switch (jsonObject.optString("input")) {
-						case "numeric": {
-							result.setInput(DvachChanConfiguration.Captcha.Input.NUMERIC);
-							break;
-						}
-						case "english": {
-							result.setInput(DvachChanConfiguration.Captcha.Input.LATIN);
-							break;
-						}
-						default: {
-							result.setInput(DvachChanConfiguration.Captcha.Input.ALL);
-							break;
-						}
-					}*/
 
-					// hotfix 07.09.2022
-					// temporarily set all input types for captcha
-					result.setInput(DvachChanConfiguration.Captcha.Input.ALL);
+					if (configuration.isFullKeyboardForCaptchaEnabled()) {
+						result.setInput(DvachChanConfiguration.Captcha.Input.ALL);
+					} else {
+						switch (jsonObject.optString("input")) {
+							case "numeric": {
+								result.setInput(DvachChanConfiguration.Captcha.Input.NUMERIC);
+								break;
+							}
+							case "english": {
+								result.setInput(DvachChanConfiguration.Captcha.Input.LATIN);
+								break;
+							}
+							default: {
+								result.setInput(DvachChanConfiguration.Captcha.Input.ALL);
+								break;
+							}
+						}
+					}
 
 				} else if (DvachChanConfiguration.CAPTCHA_TYPE_RECAPTCHA_2.equals(data.captchaType) ||
 						DvachChanConfiguration.CAPTCHA_TYPE_RECAPTCHA_2_INVISIBLE.equals(data.captchaType)) {


### PR DESCRIPTION
Добавил в настройки борды опцию для выбора полной клавиатуры для капчи. Если опция выбрана, то всегда будет использоваться полная клавиатура, если нет, то тип клавиатуры будет выбран исходя из ответа от сервера (как было раньше).

Правда, есть один баг. Если изменить опцию находясь в окне ответа в тред, то тип клавиатуры для этого треда не изменится, нужно будет либо зайти в другой тред и потом вернуться, либо перезапустить приложение. Скорее всего, пофиксить это можно только в самом клиенте.