### PR TITLE
Fourchan posting fix attempt

### DIFF
--- a/extensions/fourchan/res/values-ru/strings.xml
+++ b/extensions/fourchan/res/values-ru/strings.xml
@@ -8,5 +8,11 @@
 	<string name="preference_fix_nsfw_boards_summary">Использовать небраузерный заголовок User-Agent в NSFW разделах
 		(может сломать обход CloudFlare)</string>
 	<string name="select_the_most_readable_captcha">Выберите наиболее читаемую капчу</string>
+	<plurals name="capthca_cooldown_message__format">
+		<item quantity="one">Повторите попытку через %d секунду</item>
+		<item quantity="few">Повторите попытку через %d секунды</item>
+		<item quantity="many">Повторите попытку через %d секунд</item>
+		<item quantity="other">Повторите попытку через %d секунд</item>
+	</plurals>
 
 </resources>

--- a/extensions/fourchan/res/values/strings.xml
+++ b/extensions/fourchan/res/values/strings.xml
@@ -7,5 +7,10 @@
 	<string name="preference_fix_nsfw_boards_summary">Use non-browser User-Agent header on NSFW boards
 		(may break CloudFlare bypass)</string>
 	<string name="select_the_most_readable_captcha">Select the most readable captcha</string>
+	<plurals name="capthca_cooldown_message__format">
+		<item quantity="one">Retry attempt after %d second</item>
+		<item quantity="many">Retry attempt after %d seconds</item>
+		<item quantity="other">Retry attempt after %d seconds</item>
+	</plurals>
 
 </resources>

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanLocator.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanLocator.java
@@ -14,6 +14,7 @@ public class FourchanChanLocator extends ChanLocator {
 	private static final String HOST_BOARDS = "boards.4chan.org";
 	private static final String HOST_BOARDS_SAFE = "boards.4channel.org";
 	private static final String HOST_SYS = "sys.4chan.org";
+	private static final String HOST_SYS_SAFE = "sys.4channel.org";
 	private static final String HOST_API = "a.4cdn.org";
 	private static final String HOST_IMAGES = "i.4cdn.org";
 	private static final String HOST_IMAGES_IS1 = "is.4chan.org";
@@ -33,7 +34,7 @@ public class FourchanChanLocator extends ChanLocator {
 		addSpecialChanHost(HOST_BOARDS);
 		addSpecialChanHost(HOST_BOARDS_SAFE);
 		addSpecialChanHost(HOST_SYS);
-		addSpecialChanHost("sys.4channel.org");
+		addSpecialChanHost(HOST_SYS_SAFE);
 		addSpecialChanHost(HOST_API);
 		addSpecialChanHost(HOST_IMAGES);
 		addSpecialChanHost(HOST_IMAGES_IS1);
@@ -128,8 +129,10 @@ public class FourchanChanLocator extends ChanLocator {
 		return buildPathWithSchemeHost(true, HOST_STATIC, "image", "flags", boardName, fileName);
 	}
 
-	public Uri createSysUri(String... segments) {
-		return buildPathWithSchemeHost(true, HOST_SYS, segments);
+	public Uri createSysUri(String boardName, String... segments) {
+		FourchanChanConfiguration configuration = FourchanChanConfiguration.get(this);
+		String host = !StringUtils.isEmpty(boardName) && configuration.isSafeForWork(boardName) ? HOST_SYS_SAFE : HOST_SYS;
+		return buildPathWithSchemeHost(true, host, segments);
 	}
 
 	public Uri createSearchApiUri(String... alternation) {

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -789,6 +789,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 		HttpRequest request = new HttpRequest(uri, data)
 				.addCookie(buildCookies(captchaPassCookie))
 				.addCookie(COOKIE_FOURCHAN_PASS, fourchanPassCookie)
+				.addHeader("Sec-Fetch-Dest", "document")
+				.addHeader("Sec-Fetch-Mode", "navigate")
+				.addHeader("Sec-Fetch-Site", "same-site")
+				.addHeader("Sec-Fetch-User", "?1")
 				.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE);
 
 		/*


### PR DESCRIPTION
Исправил ситуацию, когда капча на долгом кулдауне и пользователь не мог знать, почему капча не появляется. Теперь пользователь увидит сообщение, через сколько нужно повторить попытку, если кулдаун капчи больше 10 секунд.

Зелёные (unsafe\nsfw) и Синие (safe) борды теперь используют соответствующие sys хосты (используются, например, для получения капчи) и куки. Раньше, например, при получении капчи для синей борды, использовался sys хост зелёной борды. Теперь же поведение соответствует поведению как на сайте. Я не знаю, насколько это важно, но хуже не стало.

Добавил кастомный юзер-агент при обращении к sys хостам. По какой то причине Клаудфлара не пропускает WebView, если используется дефолтный юзер-агент, но если использовать какую-нибудь строку, не похожую на валидный юзер-агент, то проверка проходит успешно.

Добавил несколько заголовков к реквесту для отправки поста. Эти заголовки используются при постинге из браузера.

С этими изменениями у меня получается более-менее стабильно постить, но для того, что бы нормально проходить проверку клаудфлары, нужны будут изменения в клиенте. Пул реквесты с этими изменениями я отправил в репозиторий клиента.