### PR TITLE
dvach: Do not re-login passcode if get http error 429 when requesting captcha

### DIFF
--- a/extensions/dvach/src/com/mishiranu/dashchan/chan/dvach/DvachChanPerformer.java
+++ b/extensions/dvach/src/com/mishiranu/dashchan/chan/dvach/DvachChanPerformer.java
@@ -858,7 +858,7 @@ public class DvachChanPerformer extends ChanPerformer {
 		Uri uri = locator.buildPath("/user/passlogin");
 		UrlEncodedEntity entity = new UrlEncodedEntity("passcode", captchaPassData);
 
-		HttpResponse response = null;
+		HttpResponse response;
 		try {
 			response = new HttpRequest(uri, preset).addCookie(buildCookies(null))
 					.setPostMethod(entity).setRedirectHandler(HttpRequest.RedirectHandler.NONE).perform();
@@ -868,7 +868,7 @@ public class DvachChanPerformer extends ChanPerformer {
 
 		String captchaPassCookie = "";
 		if (response != null) {
-			captchaPassCookie = response.getCookieValue("passcode_auth");
+			captchaPassCookie = response.getCookieValue(COOKIE_PASSCODE_AUTH);
 		}
 		if (StringUtils.isEmpty(captchaPassCookie)) {
 			throw new InvalidResponseException();
@@ -946,6 +946,10 @@ public class DvachChanPerformer extends ChanPerformer {
 				throw e;
 			}
 			exception = e;
+			boolean tooManyRequestsException = exception.getResponseCode() == 429;
+			if(tooManyRequestsException){
+				mayRelogin = false;
+			}
 		}
 
 		String apiResult = jsonObject != null ? CommonUtils.optJsonString(jsonObject, "result") : null;


### PR DESCRIPTION
If a user posts too quickly he may get "HTTP 429 Too many requests" exception when requesting captcha. In this case, we do not need to re-login passcode because the exception is not related to passcode and frequent re-logins will block passcode for some time.