### PR TITLE
Fix multiple attachments spilling out onto the next thread

### DIFF
--- a/extensions/dollchan/src/com/mishiranu/dashchan/chan/dollchan/DollchanPostsParser.java
+++ b/extensions/dollchan/src/com/mishiranu/dashchan/chan/dollchan/DollchanPostsParser.java
@@ -93,6 +93,7 @@ public class DollchanPostsParser {
 					if (holder.threads != null) {
 						holder.closeThread();
 						holder.thread = new Posts();
+						holder.attachments = null;
 					}
 				}
 			}


### PR DESCRIPTION
In a situation when a board contains a thread, which has a last post previewed with multiple attachments, those spill up onto the next thread