### PR TITLE
fourchan: fix "Invalid server response" error when getting captcha

### DIFF
--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanLocator.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanLocator.java
@@ -130,9 +130,7 @@ public class FourchanChanLocator extends ChanLocator {
 	}
 
 	public Uri createSysUri(String boardName, String... segments) {
-		FourchanChanConfiguration configuration = FourchanChanConfiguration.get(this);
-		String host = !StringUtils.isEmpty(boardName) && configuration.isSafeForWork(boardName) ? HOST_SYS_SAFE : HOST_SYS;
-		return buildPathWithSchemeHost(true, host, segments);
+		return buildPathWithSchemeHost(true, HOST_SYS, segments);
 	}
 
 	public Uri createSearchApiUri(String... alternation) {


### PR DESCRIPTION
Looks like 4chan doesn't use 4channel host anymore and all sys calls use 4chan host now. This commit fixes "Invalid server response" error when getting captcha.

I tested methods that use `createSysUri` except `onSendDeletePosts` and everything seems to work fine, but more changes related to safe/unsafe boards may be needed (e.g. 4chan/4channel pass cookies handling).