### PR TITLE
fourchan: fix missing report option

### DIFF
--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -77,7 +77,7 @@ public class FourchanChanPerformer extends ChanPerformer {
 		HttpResponse response = null;
 		if (postNumber != null) {
 			FourchanChanLocator locator = FourchanChanLocator.get(this);
-			Uri uri = locator.createSysUri(boardName, "imgboard.php").buildUpon()
+			Uri uri = locator.createSysUri(boardName, boardName, "imgboard.php").buildUpon()
 					.appendQueryParameter("mode", "report").appendQueryParameter("no", postNumber).build();
 			response = new HttpRequest(uri, preset).setSuccessOnly(false)
 					.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE)


### PR DESCRIPTION
I found out that reports don't work (the report option missing when long click on a post) because report's URI changed and has to contain board name segment now. Fixed by adding a board name as first segment of report's URI.