### PR TITLE
fourchan: Remove fake user agent and "Fix image posting" option

### DIFF
--- a/extensions/fourchan/res/values-ru/strings.xml
+++ b/extensions/fourchan/res/values-ru/strings.xml
@@ -4,9 +4,6 @@
 	<string name="preference_math_tags">Обработка [math] тегов</string>
 	<string name="preference_math_tags_summary">Показывать ссылки на изображения используя веб-сервис
 		quicklatex.com</string>
-	<string name="preference_fix_nsfw_boards">Исправление отправки изображений</string>
-	<string name="preference_fix_nsfw_boards_summary">Использовать небраузерный заголовок User-Agent в NSFW разделах
-		(может сломать обход CloudFlare)</string>
 	<string name="select_the_most_readable_captcha">Выберите наиболее читаемую капчу</string>
 	<plurals name="capthca_cooldown_message__format">
 		<item quantity="one">Повторите попытку через %d секунду</item>

--- a/extensions/fourchan/res/values/strings.xml
+++ b/extensions/fourchan/res/values/strings.xml
@@ -3,9 +3,6 @@
 
 	<string name="preference_math_tags">Handle [math] tags</string>
 	<string name="preference_math_tags_summary">Show image links using quicklatex.com web service</string>
-	<string name="preference_fix_nsfw_boards">Fix image posting</string>
-	<string name="preference_fix_nsfw_boards_summary">Use non-browser User-Agent header on NSFW boards
-		(may break CloudFlare bypass)</string>
 	<string name="select_the_most_readable_captcha">Select the most readable captcha</string>
 	<plurals name="capthca_cooldown_message__format">
 		<item quantity="one">Retry attempt after %d second</item>

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanConfiguration.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanConfiguration.java
@@ -26,7 +26,6 @@ public class FourchanChanConfiguration extends ChanConfiguration {
 	private static final String KEY_REPORT_REASONS = "report_reasons";
 
 	private static final String KEY_MATH_TAGS = "math_tags";
-	private static final String KEY_FIX_NSFW_BOARDS = "fix_nsfw_boards";
 
 	public FourchanChanConfiguration() {
 		request(OPTION_READ_THREAD_PARTIALLY);
@@ -36,7 +35,6 @@ public class FourchanChanConfiguration extends ChanConfiguration {
 		addCaptchaType(CAPTCHA_TYPE_4CHAN_CAPTCHA);
 		addCaptchaType(CAPTCHA_TYPE_RECAPTCHA_2);
 		addCustomPreference(KEY_MATH_TAGS, false);
-		addCustomPreference(KEY_FIX_NSFW_BOARDS, true);
 	}
 
 	@Override
@@ -130,12 +128,6 @@ public class FourchanChanConfiguration extends ChanConfiguration {
 			customPreference.title = resources.getString(R.string.preference_math_tags);
 			customPreference.summary = resources.getString(R.string.preference_math_tags_summary);
 			return customPreference;
-		} else if (KEY_FIX_NSFW_BOARDS.equals(key)) {
-			Resources resources = getResources();
-			CustomPreference customPreference = new CustomPreference();
-			customPreference.title = resources.getString(R.string.preference_fix_nsfw_boards);
-			customPreference.summary = resources.getString(R.string.preference_fix_nsfw_boards_summary);
-			return customPreference;
 		}
 		return null;
 	}
@@ -152,10 +144,6 @@ public class FourchanChanConfiguration extends ChanConfiguration {
 
 	public boolean isMathTagsHandlingEnabled() {
 		return get(null, KEY_MATH_TAGS, false);
-	}
-
-	public boolean isFixNsfwBoardsEnabled() {
-		return get(null, KEY_FIX_NSFW_BOARDS, true);
 	}
 
 	public boolean isSafeForWork(String boardName) {

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -55,9 +55,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 
 	private final HashMap<String, Long> lastRulesUpdate = new HashMap<>();
 
-	private final String USER_AGENT_HTTP_HEADER_NAME = "User-Agent";
-	private final String USER_AGENT_HTTP_HEADER_VALUE = "Dashchan-Fourchan";
-
 	private void updateBoardRules(HttpRequest.Preset preset,
 			String boardName, List<Posts> threads) throws HttpException {
 		Long update;
@@ -80,7 +77,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 			Uri uri = locator.createSysUri(boardName, "imgboard.php").buildUpon()
 					.appendQueryParameter("mode", "report").appendQueryParameter("no", postNumber).build();
 			response = new HttpRequest(uri, preset).setSuccessOnly(false)
-					.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE)
 					.perform();
 		}
 		List<ReportReason> reportReasons = Collections.emptyList();
@@ -488,7 +484,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 		UrlEncodedEntity entity = new UrlEncodedEntity("act", "do_login", "id", token, "pin", pin, "long_login", "yes");
 		HttpResponse response = new HttpRequest(uri, preset).setPostMethod(entity)
 				.setRedirectHandler(HttpRequest.RedirectHandler.STRICT)
-				.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE)
 				.perform();
 		String responseText = response.readString();
 		Matcher matcher = PATTERN_AUTH_MESSAGE.matcher(responseText);
@@ -579,7 +574,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 				try {
 					JSONObject jsonObject = new JSONObject(new HttpRequest(uri, data)
 							.addCookie(COOKIE_FOURCHAN_PASS, fourchanPassCookie)
-							.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE)
 							.perform()
 							.readString());
 					String newCaptchaTicket = jsonObject.optString("ticket");
@@ -811,21 +805,7 @@ public class FourchanChanPerformer extends ChanPerformer {
 				.addHeader("Sec-Fetch-Dest", "document")
 				.addHeader("Sec-Fetch-Mode", "navigate")
 				.addHeader("Sec-Fetch-Site", "same-site")
-				.addHeader("Sec-Fetch-User", "?1")
-				.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE);
-
-		/*
-		As for 20.02.23, both this nsfw fixes break posting, ignore for now
-		boolean nsfwFix = !configuration.isSafeForWork(data.boardName) && configuration.isFixNsfwBoardsEnabled();
-		if (nsfwFix) {
-			// More reliable fix: add non-browser User-Agent (breaks CloudFlare bypass)
-			request.addHeader("User-Agent", "curl/7.64.0");
-		} else {
-			// Less reliable fix: works in /b/, doesn't work in /bant/
-			request.addHeader("Accept", "text/html").addHeader("Accept-Language", "en")
-					.addHeader("Referer", uri.toString());
-		}
-		 */
+				.addHeader("Sec-Fetch-User", "?1");
 
 		HttpResponse response = request.setPostMethod(entity)
 				.setRedirectHandler(HttpRequest.RedirectHandler.STRICT).perform();
@@ -900,7 +880,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 		}
 		String responseText = new HttpRequest(uri, data).setPostMethod(entity)
 				.setRedirectHandler(HttpRequest.RedirectHandler.STRICT)
-				.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE)
 				.perform()
 				.readString();
 		Matcher matcher = PATTERN_POST_ERROR.matcher(responseText);
@@ -965,7 +944,6 @@ public class FourchanChanPerformer extends ChanPerformer {
 			HttpResponse response = new HttpRequest(uri, data).setPostMethod(entity)
 					.addCookie(COOKIE_FOURCHAN_PASS, fourchanPassCookie)
 					.setRedirectHandler(HttpRequest.RedirectHandler.STRICT)
-					.addHeader(USER_AGENT_HTTP_HEADER_NAME, USER_AGENT_HTTP_HEADER_VALUE)
 					.perform();
 			handleFourchanPass(response, data.boardName);
 			String responseText = response.readString();


### PR DESCRIPTION
Posting works better with a real user agent now. The "Fix image posting" option is removed because it is related to the removal of fake user agents and is not used.