### PR TITLE
DobrochanRefuge: thumbnail loading fix

### DIFF
--- a/extensions/refugedobrochan/build.gradle
+++ b/extensions/refugedobrochan/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'chan-extension'
 chan {
     nameUpper 'RefugeDobrochan'
     packageName 'com.trixiether.dashchan.chan.refugedobrochan'
-    versionName '1.5'
+    versionName '1.6'
     apiVersion 1
     hosts 'rf.dobrochan.net'
 }

--- a/extensions/refugedobrochan/src/com/trixiether/dashchan/chan/refugedobrochan/RefugeDobrochanChanPerformer.java
+++ b/extensions/refugedobrochan/src/com/trixiether/dashchan/chan/refugedobrochan/RefugeDobrochanChanPerformer.java
@@ -1,10 +1,29 @@
 package com.trixiether.dashchan.chan.refugedobrochan;
 
+import android.net.Uri;
+import java.net.HttpURLConnection;
+import chan.content.InvalidResponseException;
 import chan.content.VichanChanPerformer;
+import chan.http.HttpException;
+import chan.http.HttpRequest;
+import chan.http.HttpResponse;
 import chan.http.MultipartEntity;
 import chan.text.ParseException;
 
 public class RefugeDobrochanChanPerformer extends VichanChanPerformer {
+    @Override
+    public ReadContentResult onReadContent(ReadContentData data) throws HttpException, InvalidResponseException {
+        if (data.uri.toString().contains("/thumb/") && data.uri.toString().endsWith(".png")) {
+            HttpResponse response = new HttpRequest(data.uri, data).setSuccessOnly(false).perform();
+            if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND)
+            {
+                Uri webpThumbUri = Uri.parse(data.uri.toString().replace(".png", ".webp"));
+                return new ReadContentResult(new HttpRequest(webpThumbUri, data.direct).perform());
+            }
+        }
+        return super.onReadContent(data);
+    }
+
     @Override
     protected void parseAntispamFields(String text, MultipartEntity entity) throws ParseException {
         RefugeDobrochanAntispamFieldsParser.parseAndApply(text, entity, "board", "thread", "name", "email",


### PR DESCRIPTION
Recently there was an announcement saying that DobrochanRefuge now saves thumbnails in webp format. The current version of the plugin works good with old thumbnails in png format, but does not load new thumbnails in webp format. This PR contains a fix that checks for the availability of a thumbnail in png format, and if it is not available (a 404 code was received), then the webp thumbnail is loaded. I checked the functionality on DobrochanRefuge - at first glance it works fine.

Link to announcement: https://rf.dobrochan.net/vichan/d/res/2496.html#6420