### PR TITLE
fourchan: handle unsafe redirects

### DIFF
--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -55,6 +55,12 @@ public class FourchanChanPerformer extends ChanPerformer {
 
 	private final HashMap<String, Long> lastRulesUpdate = new HashMap<>();
 
+    private final HttpRequest.RedirectHandler unsafeRedirectHandler =
+            new HttpRequestUnsafeRedirectHandler();
+
+    private final HttpRequest.RedirectHandler strictUnsafeRedirectHandler =
+            new HttpRequestUnsafeRedirectHandler(HttpRequest.RedirectHandler.STRICT);
+
 	private void updateBoardRules(HttpRequest.Preset preset,
 			String boardName, List<Posts> threads) throws HttpException {
 		Long update;
@@ -76,8 +82,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 			FourchanChanLocator locator = FourchanChanLocator.get(this);
 			Uri uri = locator.createSysUri(boardName, "imgboard.php").buildUpon()
 					.appendQueryParameter("mode", "report").appendQueryParameter("no", postNumber).build();
-			response = new HttpRequest(uri, preset).setSuccessOnly(false)
-					.perform();
+			response = new HttpRequest(uri, preset)
+                    .setSuccessOnly(false)
+					.setRedirectHandler(unsafeRedirectHandler)
+                    .perform();
 		}
 		List<ReportReason> reportReasons = Collections.emptyList();
 		if (response != null) {
@@ -105,7 +113,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 		FourchanChanConfiguration configuration = FourchanChanConfiguration.get(this);
 		Uri uri = locator.createApiUri(data.boardName, (data.isCatalog() ? "catalog"
 				: Integer.toString(data.pageNumber + 1)) + ".json");
-		HttpResponse response = new HttpRequest(uri, data).setValidator(data.validator).perform();
+		HttpResponse response = new HttpRequest(uri, data)
+                .setValidator(data.validator)
+                .setRedirectHandler(unsafeRedirectHandler)
+                .perform();
 		HttpValidator validator = response.getValidator();
 		ArrayList<Posts> threads = new ArrayList<>();
 		boolean handleMathTags = configuration.isMathTagsHandlingEnabled();
@@ -173,8 +184,11 @@ public class FourchanChanPerformer extends ChanPerformer {
 		int uniquePosters = 0;
 		if (tail) {
 			Uri uri = locator.createApiUri(data.boardName, "thread", data.threadNumber + "-tail.json");
-			HttpResponse response = new HttpRequest(uri, data).setValidator(data.validator)
-					.setSuccessOnly(false).perform();
+			HttpResponse response = new HttpRequest(uri, data)
+                    .setValidator(data.validator)
+					.setSuccessOnly(false)
+                    .setRedirectHandler(unsafeRedirectHandler)
+                    .perform();
 			if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
 				TRY: try (InputStream input = response.open();
 						JsonSerial.Reader reader = JsonSerial.reader(input)) {
@@ -227,7 +241,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 			}
 		}
 		Uri uri = locator.createApiUri(data.boardName, "thread", data.threadNumber + ".json");
-		HttpResponse response = new HttpRequest(uri, data).setValidator(data.validator).perform();
+		HttpResponse response = new HttpRequest(uri, data)
+                .setValidator(data.validator)
+                .setRedirectHandler(unsafeRedirectHandler)
+                .perform();
 		try (InputStream input = response.open();
 				JsonSerial.Reader reader = JsonSerial.reader(input)) {
 			reader.startObject();
@@ -269,7 +286,9 @@ public class FourchanChanPerformer extends ChanPerformer {
 		boolean handleMathTags = configuration.isMathTagsHandlingEnabled();
 		Uri uri = locator.createSearchApiUri("b", data.boardName, "q", data.searchQuery,
 				"o", Integer.toString(10 * data.pageNumber));
-		HttpResponse response = new HttpRequest(uri, data).perform();
+		HttpResponse response = new HttpRequest(uri, data)
+                .setRedirectHandler(unsafeRedirectHandler)
+                .perform();
 		Locale locale = Locale.US;
 		String lowerSearchQuery = data.searchQuery.toLowerCase(locale);
 		try (InputStream input = response.open();
@@ -332,7 +351,9 @@ public class FourchanChanPerformer extends ChanPerformer {
 	public ReadBoardsResult onReadBoards(ReadBoardsData data) throws HttpException, InvalidResponseException {
 		FourchanChanLocator locator = FourchanChanLocator.get(this);
 		Uri uri = locator.buildPath();
-		HttpResponse response = new HttpRequest(uri, data).perform();
+		HttpResponse response = new HttpRequest(uri, data)
+                .setRedirectHandler(unsafeRedirectHandler)
+                .perform();
 		Map<String, List<String>> categoryMap;
 		try (InputStream input = response.open()) {
 			categoryMap = new FourchanBoardsParser(this).parse(input);
@@ -355,7 +376,9 @@ public class FourchanChanPerformer extends ChanPerformer {
 			}
 		}
 		uri = locator.createApiUri("boards.json");
-		response = new HttpRequest(uri, data).perform();
+		response = new HttpRequest(uri, data)
+                .setRedirectHandler(unsafeRedirectHandler)
+                .perform();
 		try (InputStream input = response.open();
 				JsonSerial.Reader reader = JsonSerial.reader(input)) {
 			reader.startObject();
@@ -407,7 +430,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 		if (data.type == ReadThreadSummariesData.TYPE_ARCHIVED_THREADS) {
 			FourchanChanLocator locator = FourchanChanLocator.get(this);
 			Uri uri = locator.createBoardUri(data.boardName, 0).buildUpon().appendPath("archive").build();
-			String responseText = new HttpRequest(uri, data).perform().readString();
+			String responseText = new HttpRequest(uri, data)
+                    .setRedirectHandler(unsafeRedirectHandler)
+                    .perform()
+                    .readString();
 			ArrayList<ThreadSummary> threadSummaries = new ArrayList<>();
 			Matcher matcher = PATTERN_ARCHIVED_THREAD.matcher(responseText);
 			while (matcher.find()) {
@@ -431,11 +457,19 @@ public class FourchanChanPerformer extends ChanPerformer {
 					"fcolor=000000&mode=0&out=1&remhost=quicklatex.com&preamble=\\usepackage{amsmath}\n" +
 					"\\usepackage{amsfonts}\n\\usepackage{amssymb}");
 			entity.setContentType("application/x-www-form-urlencoded");
-			String responseText = new HttpRequest(uri, data).setPostMethod(entity).perform().readString();
+			String responseText = new HttpRequest(uri, data)
+					.setPostMethod(entity)
+                    .setRedirectHandler(unsafeRedirectHandler)
+                    .perform()
+                    .readString();
 			String[] splitted = responseText.split("\r?\n| ");
 			if (splitted.length >= 2 && "0".equals(splitted[0])) {
 				uri = Uri.parse(splitted[1]);
-				return new ReadContentResult(new HttpRequest(uri, data).perform());
+				return new ReadContentResult(
+                        new HttpRequest(uri, data)
+                        .setRedirectHandler(unsafeRedirectHandler)
+                        .perform()
+                );
 			}
 			throw HttpException.createNotFoundException();
 		}
@@ -482,9 +516,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 		FourchanChanLocator locator = FourchanChanLocator.get(this);
 		Uri uri = locator.createSysUri(null, "auth");
 		UrlEncodedEntity entity = new UrlEncodedEntity("act", "do_login", "id", token, "pin", pin, "long_login", "yes");
-		HttpResponse response = new HttpRequest(uri, preset).setPostMethod(entity)
-				.setRedirectHandler(HttpRequest.RedirectHandler.STRICT)
-				.perform();
+		HttpResponse response = new HttpRequest(uri, preset)
+                .setPostMethod(entity)
+				.setRedirectHandler(strictUnsafeRedirectHandler)
+                .perform();
 		String responseText = response.readString();
 		Matcher matcher = PATTERN_AUTH_MESSAGE.matcher(responseText);
 		if (matcher.find()) {
@@ -572,10 +607,13 @@ public class FourchanChanPerformer extends ChanPerformer {
 			String fourchanPassCookie = getFourchanPassCookie(configuration, data.boardName);
 			while (true) {
 				try {
-					JSONObject jsonObject = new JSONObject(new HttpRequest(uri, data)
+					JSONObject jsonObject = new JSONObject(
+                            new HttpRequest(uri, data)
 							.addCookie(COOKIE_FOURCHAN_PASS, fourchanPassCookie)
-							.perform()
-							.readString());
+							.setRedirectHandler(unsafeRedirectHandler)
+                            .perform()
+							.readString()
+                    );
 					String newCaptchaTicket = jsonObject.optString("ticket");
 					if (!newCaptchaTicket.isEmpty()) {
 						saveCaptchaTicket(newCaptchaTicket);
@@ -701,7 +739,10 @@ public class FourchanChanPerformer extends ChanPerformer {
 	private ApiException.BanExtra readBanExtra(HttpRequest.Preset preset, String boardName) throws HttpException {
 		FourchanChanLocator locator = FourchanChanLocator.get(this);
 		Uri uri = locator.buildPath("banned");
-		String responseText = new HttpRequest(uri, preset).perform().readString();
+		String responseText = new HttpRequest(uri, preset)
+				.setRedirectHandler(unsafeRedirectHandler)
+				.perform()
+				.readString();
 		while (responseText.contains(RECAPTCHA_API_KEY)) {
 			CaptchaData captchaData = requireUserCaptcha(REQUIREMENT_BANNED, boardName, null, false);
 			if (captchaData == null) {
@@ -709,7 +750,11 @@ public class FourchanChanPerformer extends ChanPerformer {
 			}
 			MultipartEntity entity = new MultipartEntity();
 			entity.add("g-recaptcha-response", captchaData.get(CaptchaData.INPUT));
-			responseText = new HttpRequest(uri, preset).setPostMethod(entity).perform().readString();
+			responseText = new HttpRequest(uri, preset)
+                    .setPostMethod(entity)
+                    .setRedirectHandler(unsafeRedirectHandler)
+                    .perform()
+                    .readString();
 		}
 		HashMap<String, String> fields = new HashMap<>();
 		for (String name : Arrays.asList("reason", "startDate", "endDate")) {
@@ -808,7 +853,8 @@ public class FourchanChanPerformer extends ChanPerformer {
 				.addHeader("Sec-Fetch-User", "?1");
 
 		HttpResponse response = request.setPostMethod(entity)
-				.setRedirectHandler(HttpRequest.RedirectHandler.STRICT).perform();
+                .setRedirectHandler(strictUnsafeRedirectHandler)
+                .perform();
 		handleFourchanPass(response, data.boardName);
 		String responseText = response.readString();
 
@@ -879,8 +925,8 @@ public class FourchanChanPerformer extends ChanPerformer {
 			entity.add("onlyimgdel", "on");
 		}
 		String responseText = new HttpRequest(uri, data).setPostMethod(entity)
-				.setRedirectHandler(HttpRequest.RedirectHandler.STRICT)
-				.perform()
+				.setRedirectHandler(strictUnsafeRedirectHandler)
+                .perform()
 				.readString();
 		Matcher matcher = PATTERN_POST_ERROR.matcher(responseText);
 		if (matcher.find()) {
@@ -943,8 +989,8 @@ public class FourchanChanPerformer extends ChanPerformer {
 			String fourchanPassCookie = getFourchanPassCookie(configuration, data.boardName);
 			HttpResponse response = new HttpRequest(uri, data).setPostMethod(entity)
 					.addCookie(COOKIE_FOURCHAN_PASS, fourchanPassCookie)
-					.setRedirectHandler(HttpRequest.RedirectHandler.STRICT)
-					.perform();
+					.setRedirectHandler(strictUnsafeRedirectHandler)
+                    .perform();
 			handleFourchanPass(response, data.boardName);
 			String responseText = response.readString();
 			Matcher matcher = PATTERN_REPORT_MESSAGE.matcher(responseText);

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/HttpRequestUnsafeRedirectHandler.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/HttpRequestUnsafeRedirectHandler.java
@@ -1,0 +1,55 @@
+package com.mishiranu.dashchan.chan.fourchan;
+
+import android.net.Uri;
+
+import chan.http.HttpException;
+import chan.http.HttpRequest;
+import chan.http.HttpResponse;
+
+class HttpRequestUnsafeRedirectHandler implements HttpRequest.RedirectHandler {
+
+    private HttpRequest.RedirectHandler delegate = null;
+
+    HttpRequestUnsafeRedirectHandler() {
+
+    }
+
+    HttpRequestUnsafeRedirectHandler(HttpRequest.RedirectHandler delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Action onRedirect(HttpResponse response) throws HttpException {
+        Uri originalUri = response.getRequestedUri();
+        Uri redirectUri = response.getRedirectedUri();
+
+        if (originalUri != null && redirectUri != null) {
+            String originalScheme = originalUri.getScheme();
+            String redirectScheme = redirectUri.getScheme();
+
+            if (originalScheme != null && redirectScheme != null) {
+                String HTTP_SCHEME = "http";
+                String HTTPS_SCHEME = "https";
+
+                boolean unsafeRedirect =
+                        originalScheme.equals(HTTPS_SCHEME) &&
+                                redirectScheme.equals(HTTP_SCHEME);
+
+                if (unsafeRedirect) {
+                    Uri httpsRedirectUri = redirectUri
+                            .buildUpon()
+                            .scheme(HTTPS_SCHEME)
+                            .build();
+
+                    response.setRedirectedUri(httpsRedirectUri);
+                }
+            }
+        }
+
+        if (delegate != null) {
+            return delegate.onRedirect(response);
+        } else {
+            return HttpRequest.RedirectHandler.Action.RETRANSMIT;
+        }
+    }
+}


### PR DESCRIPTION
For whatever reason Fourchan started to use HTTP URLs when redirecting to some special pages (e.g. redirect to "not found" page if a thread is not found) and if the original URL was HTTPS then the client considers this redirect as unsafe and throws exception. That leads to "Unsafe redirect" toast message. HttpRequestUnsafeRedirectHandler class checks schemes of all redirects and if it finds "unsafe" redirects it replaces HTTP scheme with HTTPS and signals to the client to process the redirect.

Also in the original code some HTTP request were called with RedirectHandler.STRICT. I don't know how important is this so i delegated the redirect to this handler in the places when it was used in the original code.