### PR TITLE
fourchan: fix thread refresh when there are few posts in the thread

### DIFF
--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -168,7 +168,8 @@ public class FourchanChanPerformer extends ChanPerformer {
 		FourchanChanLocator locator = FourchanChanLocator.get(this);
 		FourchanChanConfiguration configuration = FourchanChanConfiguration.get(this);
 		boolean handleMathTags = configuration.isMathTagsHandlingEnabled();
-		boolean tail = data.partialThreadLoading && data.lastPostNumber != null;
+		boolean tail = ThreadsWithTailCache.INSTANCE.contains(data.threadNumber) &&
+				data.partialThreadLoading && data.lastPostNumber != null;
 		ArrayList<Post> posts = new ArrayList<>();
 		int uniquePosters = 0;
 		if (tail) {

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanModelMapper.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/FourchanModelMapper.java
@@ -201,6 +201,20 @@ public class FourchanModelMapper {
 					}
 					break;
 				}
+                case "tail_size": {
+                      /*
+                    	This check is probably redundant because i've never seen tail_size
+                    	less than 50 but i keep it just in case.
+                     */
+                    if (reader.nextInt() > 0) {
+						/*
+							Only the first post has tail_size, and the number of the first
+                    	    post is the number of the thread.
+						 */
+                        ThreadsWithTailCache.INSTANCE.add(post.getPostNumber());
+                    }
+                    break;
+                }
 				default: {
 					reader.skip();
 					break;

--- a/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/ThreadsWithTailCache.java
+++ b/extensions/fourchan/src/com/mishiranu/dashchan/chan/fourchan/ThreadsWithTailCache.java
@@ -1,0 +1,35 @@
+package com.mishiranu.dashchan.chan.fourchan;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class ThreadsWithTailCache {
+    static final ThreadsWithTailCache INSTANCE = new ThreadsWithTailCache();
+
+    private static final Object VALUE = new Object();
+
+    private final int MAXIMUM_CAPACITY = 20;
+
+    // actually unused because removeEldestEntry will remove before resize capacity is reached
+    private final float LOAD_FACTOR = 1F;
+
+    private final LinkedHashMap<String, Object> cache =
+            new LinkedHashMap<String, Object>(MAXIMUM_CAPACITY, LOAD_FACTOR, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, Object> eldest) {
+            return size() > MAXIMUM_CAPACITY;
+        }
+    };
+
+    private ThreadsWithTailCache() {
+    }
+
+    synchronized boolean contains(String threadNumber) {
+        return cache.get(threadNumber) != null;
+    }
+
+    synchronized void add(String threadNumber) {
+        cache.put(threadNumber, VALUE);
+    }
+
+}


### PR DESCRIPTION
Recently Fourchan stopped provide a tail (most recent messages) for a thread with a few posts in it, now in this case it returns "404 not found" error page. I added ThreadsWithTailCache class that keeps numbers of threads that has enough messages to use tail request. These numbers are added when parsing a post in FourchanModelMapper. If a thread is long enough the first post will have "tail_size" property in JSON response. FourchanChanPerformer.onReadPosts now checks if the thread's number in the ThreadsWithTailCache before performing tail request.